### PR TITLE
pc - add placeholder pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,7 +41,7 @@ function App() {
             </>
           )
         }
-         {
+        {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/restaurants" element={<RestaurantIndexPage />} />
@@ -56,7 +56,21 @@ function App() {
             </>
           )
         }
-
+         {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
+              <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,11 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
+import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
+import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,6 +56,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
+                  <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/pages/Placeholder/PlaceholderCreatePage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function PlaceholderCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Placeholder/PlaceholderCreatePage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderCreatePage.js
@@ -6,7 +6,7 @@ export default function PlaceholderCreatePage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>This page not yet implemented</h1>
+        <h1>Create page not yet implemented</h1>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Placeholder/PlaceholderEditPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderEditPage.js
@@ -6,7 +6,7 @@ export default function PlaceholderEditPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>This page not yet implemented</h1>
+        <h1>Edit page not yet implemented</h1>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Placeholder/PlaceholderEditPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function PlaceholderEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
@@ -6,9 +6,9 @@ export default function PlaceholderIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>This page not yet implemented</h1>
-        <a href="/placeholder/create">Create</a>
-        <a href="/placeholder/edit/1">Edit</a>
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function PlaceholderIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page not yet implemented</h1>
+        <a href="/placeholder/create">Create</a>
+        <a href="/placeholder/edit/1">Edit</a>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
@@ -3,14 +3,28 @@ import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
 describe("PlaceholderCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
     const queryClient = new QueryClient();
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "Create page not yet implemented";
-
+        setupUserOnly();
+       
         // act
         render(
             <QueryClientProvider client={queryClient}>
@@ -21,7 +35,7 @@ describe("PlaceholderCreatePage tests", () => {
         );
 
         // assert
-        expect(screen.getByText(expectedText)).toBeInTheDocument();
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
     });
 
 });

--- a/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+describe("PlaceholderCreatePage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        const expectedText = "This page not yet implemented";
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText(expectedText)).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderCreatePage.test.js
@@ -9,7 +9,7 @@ describe("PlaceholderCreatePage tests", () => {
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "This page not yet implemented";
+        const expectedText = "Create page not yet implemented";
 
         // act
         render(

--- a/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
@@ -3,13 +3,28 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
 describe("PlaceholderEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
     const queryClient = new QueryClient();
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "Edit page not yet implemented";
+        setupUserOnly();
 
         // act
         render(
@@ -21,7 +36,7 @@ describe("PlaceholderEditPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText(expectedText)).toBeInTheDocument();
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
     });
 
 });

--- a/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
@@ -9,7 +9,7 @@ describe("PlaceholderEditPage tests", () => {
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "This page not yet implemented";
+        const expectedText = "Edit page not yet implemented";
 
         // act
         render(

--- a/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderEditPage.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+describe("PlaceholderEditPage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        const expectedText = "This page not yet implemented";
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText(expectedText)).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+describe("PlaceholderIndexPage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        const expectedText = "This page not yet implemented";
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText(expectedText)).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
@@ -3,13 +3,28 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
 describe("PlaceholderIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
     const queryClient = new QueryClient();
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "Index page not yet implemented";
+        setupUserOnly();
 
         // act
         render(
@@ -21,7 +36,7 @@ describe("PlaceholderIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText(expectedText)).toBeInTheDocument();
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
         expect(screen.getByText("Create")).toBeInTheDocument();
         expect(screen.getByText("Edit")).toBeInTheDocument();
     });

--- a/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderIndexPage.test.js
@@ -9,7 +9,7 @@ describe("PlaceholderIndexPage tests", () => {
     test("Renders expected content", () => {
         // arrange
 
-        const expectedText = "This page not yet implemented";
+        const expectedText = "Index page not yet implemented";
 
         // act
         render(
@@ -22,6 +22,8 @@ describe("PlaceholderIndexPage tests", () => {
 
         // assert
         expect(screen.getByText(expectedText)).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
     });
 
 });


### PR DESCRIPTION
In this PR, we add placeholder pages to serve as examples for how to set up placeholders for the pages for CRUD operations on a new database table.